### PR TITLE
Fix constructor removing query in current url

### DIFF
--- a/src/Kdyby/Google/Google.php
+++ b/src/Kdyby/Google/Google.php
@@ -89,7 +89,7 @@ class Google extends Object
 	 */
 	public function getCurrentUrl()
 	{
-		return $this->httpRequest->url;
+		return clone $this->httpRequest->url;
 	}
 
 


### PR DESCRIPTION
Removing query on current url broke Facebook auth when both were used in the same presenter and passed via `Presenter::__construct`.
