### PR TITLE
Fixed bug with refresh token

### DIFF
--- a/src/Kdyby/Google/Google.php
+++ b/src/Kdyby/Google/Google.php
@@ -284,13 +284,13 @@ class Google extends Object
 
 		if (empty($this->session->access_token) && !empty($this->session->refresh_token)) {
 			/** @var \Google_Auth_OAuth2 $auth  */
-			$auth = $this->getClient()->getAuth();
+			$auth = $this->client->getAuth();
 
 			try {
 				$auth->refreshToken($this->session->refresh_token);
 				$accessToken = Json::decode($auth->getAccessToken(), Json::FORCE_ARRAY);
 
-				if (empty($response) || !is_array($response)) {
+				if (empty($accessToken) || !is_array($accessToken)) {
 					throw new UnexpectedValueException('Access token is expected to be a valid json array.');
 				}
 


### PR DESCRIPTION
When you try to use refresh token, you will get infinite loop error caused by the call "getClient" which is traying to get access token.
And also i fixed typo with response vs accessToken.
