### PR TITLE
Google already supports query string in redirect URI parameter.

### DIFF
--- a/src/Kdyby/Google/Google.php
+++ b/src/Kdyby/Google/Google.php
@@ -102,7 +102,7 @@ class Google extends Object
 			$this->client->setAccessToken(json_encode($token));
 		}
 
-		$this->client->setRedirectUri((string) $this->getCurrentUrl()->setQuery(''));
+		$this->client->setRedirectUri((string) $this->getCurrentUrl());
 
 		return $this->client;
 	}
@@ -335,7 +335,7 @@ class Google extends Object
 		}
 
 		try {
-			$this->client->setRedirectUri((string) $this->getCurrentUrl()->setQuery(''));
+			$this->client->setRedirectUri((string) $this->getCurrentUrl());
 			$response = Json::decode($this->client->authenticate($code), Json::FORCE_ARRAY);
 
 			if (empty($response) || !is_array($response)) {
@@ -445,7 +445,7 @@ class Google extends Object
 			return $this->session->verified_id_token['payload'];
 		}
 
-		$this->client->setRedirectUri((string) $this->getCurrentUrl()->setQuery(''));
+		$this->client->setRedirectUri((string) $this->getCurrentUrl());
 
 		/** @var \Google_Auth_OAuth2 $auth */
 		$auth = $this->client->getAuth();


### PR DESCRIPTION
Or exists some reason why query is reset?
