### PR TITLE
Pass api key for simple auth to client

### DIFF
--- a/src/Kdyby/Google/Configuration.php
+++ b/src/Kdyby/Google/Configuration.php
@@ -74,6 +74,7 @@ class Configuration extends Object
 		$client->setClientId($this->clientId);
 		$client->setClientSecret($this->clientSecret);
 		$client->setScopes($this->scopes);
+		$client->setDeveloperKey($this->apiKey);
 	}
 
 


### PR DESCRIPTION
Currently, API key is not passed anywhere from Configuration, therefore request cannot use Google Simple Auth...

This is basically hotfix, to make it work with rederfinition of ```@apiAuth``` service in config.


There should probably be some config option to setup simple auth instead of OAuth. Should I try to prepare something?