### PR TITLE
Nette/Utils 3.0 tiny fix

### DIFF
--- a/src/Kdyby/Google/Dialog/AbstractDialog.php
+++ b/src/Kdyby/Google/Dialog/AbstractDialog.php
@@ -62,7 +62,7 @@ abstract class AbstractDialog extends PresenterComponent
 	public function __construct(Google $google)
 	{
 		$this->google = $google;
-		$this->config = $google->config;
+		$this->config = $google->getConfig();
 		$this->session = $google->getSession();
 
 		parent::__construct();


### PR DESCRIPTION
Deprecated getter without annotation or use getConfig().
https://github.com/nette/utils/commit/f6db905c49d4cbfeba9d4f8e9cf3ccdca89647c1#diff-d4f9a20a52fa2979739bbe6fb15b6458